### PR TITLE
If command have no parameters create it in SendCommand

### DIFF
--- a/src/BaristaLabs.ChromeDevTools.RemoteInterface/ProtocolDefinition/CommandDefinition.cs
+++ b/src/BaristaLabs.ChromeDevTools.RemoteInterface/ProtocolDefinition/CommandDefinition.cs
@@ -41,5 +41,9 @@
             get;
             set;
         }
+
+        [JsonIgnore]
+        public bool NoParameters => Parameters == null || Parameters.Count == 0;
+
     }
 }

--- a/src/RemoteInterfaceGeneratorCLI/Templates/domain.hbs
+++ b/src/RemoteInterfaceGeneratorCLI/Templates/domain.hbs
@@ -28,9 +28,9 @@
         /// <summary>
         /// {{Description}}
         /// </summary>
-        public async Task<{{dehumanize Name}}CommandResponse> {{dehumanize Name}}({{dehumanize Name}}Command command, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+        public async Task<{{dehumanize Name}}CommandResponse> {{dehumanize Name}}({{dehumanize Name}}Command command{{#if NoParameters}} = null{{/if}}, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
         {
-            return await m_session.SendCommand<{{dehumanize Name}}Command, {{dehumanize Name}}CommandResponse>(command, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
+            return await m_session.SendCommand<{{dehumanize Name}}Command, {{dehumanize Name}}CommandResponse>(command{{#if NoParameters}} ?? new {{dehumanize Name}}Command(){{/if}}, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
         }
     {{/each}}
 


### PR DESCRIPTION
If command have no parameters, better to write DevTools.Session.Network.GetAllCookies() then DevTools.Session.Network.GetAllCookies(new GetAllCookiesCommand()).
Commit creates it in SendCommand: 

        public async Task<GetAllCookiesCommandResponse> GetAllCookies(GetAllCookiesCommand command = null, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
        {
            return await m_session.SendCommand<GetAllCookiesCommand, GetAllCookiesCommandResponse>(command ?? new GetAllCookiesCommand(), cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
        }

Or remove command from method props at all.

        public async Task<GetAllCookiesCommandResponse> GetAllCookies(CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
        {
            return await m_session.SendCommand<GetAllCookiesCommand, GetAllCookiesCommandResponse>(new GetAllCookiesCommand(), cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
        }