### PR TITLE
added mapping for binary type to fix unhandled exception in Chrome 72 or greater

### DIFF
--- a/src/BaristaLabs.ChromeDevTools.RemoteInterface/CodeGen/Utility.cs
+++ b/src/BaristaLabs.ChromeDevTools.RemoteInterface/CodeGen/Utility.cs
@@ -99,6 +99,9 @@
                     case "array":
                         mappedType = GetTypeMappingForType(typeDefinition.Items, domainDefinition, knownTypes, true);
                         break;
+                    case "binary":
+                        mappedType = "byte[]";
+                        break;
                     default:
                         throw new InvalidOperationException($"Unmapped data type: {type}");
                 }


### PR DESCRIPTION
Fix for https://github.com/BaristaLabs/chrome-dev-tools-generator/issues/14